### PR TITLE
Volt panda CAN forwarding comments

### DIFF
--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -360,7 +360,7 @@ void can_rx(uint8_t can_number) {
 
       int dst_can_idx = -1; // default = no forward
     
-      // Received on GMLAN, bus=1 (from Voltboard VT)
+      // Received on Object CAN, bus=1 (from Voltboard VT)
       // 0x180 (384)  = LKA Steering command
       // 0x409 (1033) = ASCM Keep Alive
       // 0x2cb (715)  = Gas Regen Command
@@ -368,7 +368,7 @@ void can_rx(uint8_t can_number) {
       if (bus_number == 1 && (addr == 0x180 || addr == 0x409 || addr == 0x2cb || addr == 0x370)) {
         dst_can_idx = 0; // Sent to Powertrain CAN
         
-      // Received on GMLAN, bus=1 (from Voltboard VT)
+      // Received on Object CAN, bus=1 (from Voltboard VT)
       // 0x315 (789) = Friction Brake command (normally Chassis CAN bus command)
       } else if (bus_number == 1 && addr == 0x315) {
         dst_can_idx = 2; // Sent to Chassis CAN
@@ -386,7 +386,7 @@ void can_rx(uint8_t can_number) {
       // 840 = Wheel speed (front)
       // 842 = Wheel speed (rear)
       } else if (bus_number == 0 && (addr == 189 || addr == 190 || addr == 241 || addr == 298 || addr == 309 || addr == 320 || addr == 388 || addr == 417 || addr == 481 || addr == 485 || addr == 840 || addr == 842)) {
-        dst_can_idx = 1; // Sent to GMLAN (to Voltboard VT)
+        dst_can_idx = 1; // Sent to Object CAN (to Voltboard VT)
       }
       if (dst_can_idx != -1) {
         CAN_FIFOMailBox_TypeDef to_send;

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -359,12 +359,21 @@ void can_rx(uint8_t can_number) {
       }
 
       int dst_can_idx = -1;
+    
+      // Powertrain CAN bus (??)
+      // 0x180 (384)  = LKA Steering command
+      // 0x409 (1033) = ASCM Keep Alive
+      // 0x2cb (715)  = Gas Regen Command
+      // 0x370 (880)  = Cruise Control Status
       if (bus_number == 1 && (addr == 0x180 || addr == 0x409 || addr == 0x2cb || addr == 0x370)) {
         dst_can_idx = 0;
+        
+      // Chassis CAN bus (??)
+      // 0x315 (789) = Friction Brake command
       } else if (bus_number == 1 && addr == 0x315) {
         dst_can_idx = 2;
         
-      // Powertrain CAN bus
+      // Powertrain CAN bus (??)
       // 189 = Regen Paddle
       // 190 = Accelerator Position
       // 241 = Brake Pedal Position

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -360,20 +360,20 @@ void can_rx(uint8_t can_number) {
 
       int dst_can_idx = -1;
     
-      // Powertrain CAN bus (??)
+      // Received on GMLAN (from Voltboard VT)
       // 0x180 (384)  = LKA Steering command
       // 0x409 (1033) = ASCM Keep Alive
       // 0x2cb (715)  = Gas Regen Command
       // 0x370 (880)  = Cruise Control Status
       if (bus_number == 1 && (addr == 0x180 || addr == 0x409 || addr == 0x2cb || addr == 0x370)) {
-        dst_can_idx = 0;
+        dst_can_idx = 0; // Sent to Powertrain CAN
         
-      // Chassis CAN bus (??)
-      // 0x315 (789) = Friction Brake command
+      // Received on GMLAN (from Voltboard VT)
+      // 0x315 (789) = Friction Brake command (normally Chassis CAN bus command)
       } else if (bus_number == 1 && addr == 0x315) {
-        dst_can_idx = 2;
+        dst_can_idx = 2; // Sent to Chassis CAN
         
-      // Powertrain CAN bus (??)
+      // Received on Powertrain CAN bus
       // 189 = Regen Paddle
       // 190 = Accelerator Position
       // 241 = Brake Pedal Position
@@ -386,7 +386,7 @@ void can_rx(uint8_t can_number) {
       // 840 = Wheel speed (front)
       // 842 = Wheel speed (rear)
       } else if (bus_number == 0 && (addr == 189 || addr == 190 || addr == 241 || addr == 298 || addr == 309 || addr == 320 || addr == 388 || addr == 417 || addr == 481 || addr == 485 || addr == 840 || addr == 842)) {
-        dst_can_idx = 1;
+        dst_can_idx = 1; // Sent to GMLAN (to Voltboard VT)
       }
       if (dst_can_idx != -1) {
         CAN_FIFOMailBox_TypeDef to_send;

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -358,9 +358,9 @@ void can_rx(uint8_t can_number) {
         addr = to_push.RIR >> 21;
       }
 
-      int dst_can_idx = -1;
+      int dst_can_idx = -1; // default = no forward
     
-      // Received on GMLAN (from Voltboard VT)
+      // Received on GMLAN, bus=1 (from Voltboard VT)
       // 0x180 (384)  = LKA Steering command
       // 0x409 (1033) = ASCM Keep Alive
       // 0x2cb (715)  = Gas Regen Command
@@ -368,12 +368,12 @@ void can_rx(uint8_t can_number) {
       if (bus_number == 1 && (addr == 0x180 || addr == 0x409 || addr == 0x2cb || addr == 0x370)) {
         dst_can_idx = 0; // Sent to Powertrain CAN
         
-      // Received on GMLAN (from Voltboard VT)
+      // Received on GMLAN, bus=1 (from Voltboard VT)
       // 0x315 (789) = Friction Brake command (normally Chassis CAN bus command)
       } else if (bus_number == 1 && addr == 0x315) {
         dst_can_idx = 2; // Sent to Chassis CAN
         
-      // Received on Powertrain CAN bus
+      // Received on Powertrain CAN, bus=0
       // 189 = Regen Paddle
       // 190 = Accelerator Position
       // 241 = Brake Pedal Position

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -363,6 +363,19 @@ void can_rx(uint8_t can_number) {
         dst_can_idx = 0;
       } else if (bus_number == 1 && addr == 0x315) {
         dst_can_idx = 2;
+        
+      // Powertrain CAN bus
+      // 189 = Regen Paddle
+      // 190 = Accelerator Position
+      // 241 = Brake Pedal Position
+      // 298 = Door Status
+      // 309 = Park/Neutral/Drive/Reverse
+      // 320 = Turn Signals
+      // 388 = Hands off steering detection / Torque status
+      // 481 = Steering wheel buttons
+      // 485 = Steering wheel angle
+      // 840 = Wheel speed (front)
+      // 842 = Wheel speed (rear)
       } else if (bus_number == 0 && (addr == 189 || addr == 190 || addr == 241 || addr == 298 || addr == 309 || addr == 320 || addr == 388 || addr == 417 || addr == 481 || addr == 485 || addr == 840 || addr == 842)) {
         dst_can_idx = 1;
       }


### PR DESCRIPTION
Reading through your CAN forwarding changes to the Panda firmware for the Volt, (https://github.com/vntarasov/panda/commit/c1c765eca1f943f56160fe1cff78623dd5c4ae48) I added some comments to make it more readable for myself.

I think if you were deep into the code, you'd understand the below: (but not if you just glanced over things)

- Panda can access: Powertrain CAN (pin 6/14, CAN1, Bus 0); Object CAN (CAN2, Bus 1); Chassis CAN (pin 12/13, CAN3, Bus 2)  (Panda cannot see GMLAN due to shared GMLAN/CAN2 design)
- Voltboard VT can access: GMLAN, Object CAN
- ASCM: Powered off, but all bus continuity is preserved (RX1(left) cable has jumpers, RX2(right) left in place)